### PR TITLE
Add timeline

### DIFF
--- a/src/app/search/AudioClipper.jsx
+++ b/src/app/search/AudioClipper.jsx
@@ -213,6 +213,12 @@ export default function AudioClipper({ file, setClip }) {
           visibility="hidden"
         />
       </Box>
+      <Box
+        left="0"
+        id="timeline"
+        width="100%"
+      />
+      <Text fontSize="xs" m={1} textAlign="center">Time (Seconds)</Text>
       {isClipping && (
         <Center>
           <HStack mt="2" gap="5" align="center">

--- a/src/app/search/hooks/useSpectrogram.js
+++ b/src/app/search/hooks/useSpectrogram.js
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import WaveSurfer from 'wavesurfer.js';
 import SpectrogramPlugin from 'wavesurfer.js/dist/plugin/wavesurfer.spectrogram';
+import TimelinePlugin from 'wavesurfer.js/src/plugin/timeline';
 
 const MAX_ZOOM = 5;
 
@@ -32,6 +33,12 @@ export default function useSpectrogramNavigation(file, waveformId, spectrogramId
             container: `#${CSS.escape(spectrogramId)}`,
             labels: false,
             height: SPECTROGRAM_HEIGHT,
+        }),
+        TimelinePlugin.create({
+          container: '#timeline',
+          timeInterval: 0.5,
+          primaryLabelInterval: 2,
+          secondaryLabelInterval: 10,
         })
       ]
     });


### PR DESCRIPTION
Contributes to #56 

This currently sets a `timeInterval` of 0.5 seconds, and a primary label on every second. This looks unreadable on longer audio files, but is the only way I've found to display a 0.5 second tick mark, or even 1 second label, on shorter clips. Playing with the max zoom and the minPxPerSecond can achieve different results if desired.

I used the [timeline docs](https://wavesurfer-js.org/examples/#timeline-custom.js) and [plugin code](https://unpkg.com/wavesurfer.js@7.0.0-beta.7/dist/plugins/timeline.js) to determine the options here.

![image](https://github.com/developmentseed/bioacoustics-frontend/assets/12634024/8df7cad3-45d6-49f8-909e-39273a7e6f8a)
