### PR TITLE
fix: Handle dragging outside the spectrogram area

### DIFF
--- a/src/app/search/hooks/useSpectrogram.js
+++ b/src/app/search/hooks/useSpectrogram.js
@@ -132,18 +132,18 @@ export default function useSpectrogramNavigation(file, waveformId, spectrogramId
 
   // Event handler for mouse-up events over the spectrogram
   // Deactivates panning by removing the mouse-move handler
-  const handleMouseUp = useCallback((e) => {
-    e.target.removeEventListener('mousemove', handleMouseMove);
-    e.target.removeEventListener('mouseup', handleMouseUp);
+  const handleMouseUp = useCallback(() => {
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseup', handleMouseUp);
     setSpectrogramCursor('grab');
     setTimeout(() => hasDragged.current = false, 50);
   }, [handleMouseMove]);
 
-    // Event handler for mouse-down events over the spectrogram
+  // Event handler for mouse-down events over the spectrogram
   // Activates panning by registering the mouse-move handler
-  const handleMouseDown = useCallback((e) => {
-    e.target.addEventListener('mousemove', handleMouseMove);
-    e.target.addEventListener('mouseup', handleMouseUp);
+  const handleMouseDown = useCallback(() => {
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
     setSpectrogramCursor('ew-resize');
   }, [handleMouseMove, handleMouseUp]);
 


### PR DESCRIPTION
Fix #52

This issues happens when you start dragging the spectrogram and then move the mouse outside the spectrogram area. In that case the `mouseup` event doesn't fire so dragging never ends and you're stuck in drag mode. 

Two ways we can fix this:

1. Handle the `mouseout` event and end the ongoing drag. So when you start dragging and move outside the spectrogram dragging will end.
2. Register the `mousemove` and `mouseup` events on the `document` instead of the spectrogram. That way users can continue dragging even if the mouse is outside the spectrogram area. Dragging will only end when you lift mouse pointer up.

Both are equally straightforward to implement. Option 1 seems more harsh on the user because dragging will end if you leave even by just one pixel. 

I went for option 2 but can change to option 1 if necessary. 
