### PR TITLE
Use default wavesurfer timeline plugin settings

### DIFF
--- a/src/app/search/hooks/useSpectrogram.js
+++ b/src/app/search/hooks/useSpectrogram.js
@@ -36,9 +36,6 @@ export default function useSpectrogramNavigation(file, waveformId, spectrogramId
         }),
         TimelinePlugin.create({
           container: '#timeline',
-          timeInterval: 0.5,
-          primaryLabelInterval: 2,
-          secondaryLabelInterval: 10,
         })
       ]
     });


### PR DESCRIPTION
As mentioned, the default timeline plugin for wavesurfer marks ticks dynamically, and can more easily transition between short and long clips. While this is better for long clips greater than 1 minute, it doesn't allow us to show the precision of 0.5 second ticks and a label at each second. Posting this as a demonstration; could potentially be improved upon for greater improvement at lower time settings, or demonstrated to stakeholders for further input.

A long clip:
https://github.com/developmentseed/bioacoustics-frontend/assets/12634024/4abd45a1-d4ac-4970-8087-3c38ba13a0cd

A short clip (5 seconds):
![image](https://github.com/developmentseed/bioacoustics-frontend/assets/12634024/93ad1a5b-0d32-4f09-8bf8-ae0d6a053a57)

cc @geohacker @oliverroick 

Contributes to #71. 