### PR TITLE
embed once before searching

### DIFF
--- a/src/app/search/hooks/useSearchForm.js
+++ b/src/app/search/hooks/useSearchForm.js
@@ -115,7 +115,6 @@ export default function useSearchForm() {
     const batchSize = 3;
     const audioUpload = await prepareAudioForUpload(file);
     const embedding = await fetchEmbedding(audioUpload);
-    const embeddingPayload = JSON.stringify(embedding.embedding);
 
     for (let pageOffset = 0; pageOffset < numPages; pageOffset += batchSize) {
       await Promise.all(


### PR DESCRIPTION
Based on https://github.com/developmentseed/bioacoustics-api/issues/27 — the frontend now uses the /embed endpoint once to create the embedding and search requests don't have to create always.