### PR TITLE
feat: Automatically add clip to current spectrogram center

### DIFF
--- a/src/app/search/hooks/useClipper.js
+++ b/src/app/search/hooks/useClipper.js
@@ -50,6 +50,9 @@ export default function useClipper(duration, spectrogramCenter, zoom, spectrogra
 
   const handleClipButtonClick = () => {
     setIsClipping(true);
+    if (!clipCenter) {
+      setClipCenter(spectrogramCenter * duration);
+    }
   };
 
   const handleCancelButtonClick = () => {


### PR DESCRIPTION
Implements #84 

Sets the `clipCenter` state when clipping is activated and no clip has been set previously. 
