### PR TITLE
Add drag-n-drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prop-types": "^15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-dropzone": "^14.2.3",
     "react-icons": "^4.8.0",
     "wavesurfer.js": "^6.6.3"
   },

--- a/src/app/search/AudioSelectForm.jsx
+++ b/src/app/search/AudioSelectForm.jsx
@@ -1,51 +1,61 @@
-import { useRef, useState } from 'react';
+import { useCallback } from 'react';
 import T from 'prop-types';
 import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import { useDropzone } from 'react-dropzone';
 
-import { ACCEPTED_AUDIO_TYPES } from '@/settings';
+import { ACCEPTED_FILE_TYPES } from '@/settings';
 import { Error } from '@/components';
 import useUploadValidation from './hooks/useUploadValidation';
 
 export default function AudioSelectForm({ handleFileSelect }) {
-  const inputRef = useRef();
-  const [ name, setName ] = useState();
-  const { error, handleFileChange: validate } = useUploadValidation(handleFileSelect);
+  const { error, validator: uploadValidator } = useUploadValidation();
 
-  const handleFileChange = async (e) => {
-    setName(e.target.files[0].name);
-    validate(e);
-  };
+  // CUSTOM FUNCTIONS FOR DROPZONE //
+  const onDrop = useCallback(async (files) => {
+    await handleFileSelect(files[0]);
+  }, [handleFileSelect]);
+
+  // DROPZONE DEFS //
+  const { getRootProps, getInputProps, inputRef, isDragActive, acceptedFiles, fileRejections } =
+    useDropzone({
+      accept: ACCEPTED_FILE_TYPES,
+      // validator: uploadValidator,
+      maxFiles: 1,
+      multiple: false,
+      onDrop
+    });
+    // console.log(acceptedFiles, fileRejections);
 
   return (
     <Box bg="white" p="2" borderRadius="12" boxShadow="lg">
       <Box
         border="2px dashed"
-        bg="blackAlpha.50"
-        borderColor="primary.400"
+        bg={isDragActive ? 'green.50' : 'blackAlpha.50'}
+        borderColor={isDragActive ? 'primary.400' : 'neutral.300'}
         borderRadius="6"
         textAlign="center"
         p="5"
         mt="1"
+        {...getRootProps()}
       >
         <Text>Click to select from your device</Text>
-        <Text
-          id="file-hint"
-          color="neutral.300"
-          mb="3"
-          fontSize="sm"
-        >
+        <Text id="file-hint" color="neutral.300" mb="3" fontSize="sm">
           Maximum audio length 5 minutes. Maximum file size 1 Gb
         </Text>
         <input
           ref={inputRef}
           type="file"
           name="file"
-          onChange={handleFileChange}
           aria-describedby="file-hint"
           style={{ display: 'none' }}
-          accept={ACCEPTED_AUDIO_TYPES.join(',')}
+          {...getInputProps()}
         />
-        <Flex gap="2" justifyContent="center" alignItems={['center', null, 'baseline']} flexDirection={['column', null, 'row']}>
+        <Flex
+          gap="2"
+          justifyContent="center"
+          alignItems={['center', null, 'baseline']}
+          flexDirection={['column', null, 'row']}
+        >
           <Button
             type="button"
             variant="primary"
@@ -54,14 +64,13 @@ export default function AudioSelectForm({ handleFileSelect }) {
           >
             Select File
           </Button>
-          {name && <Text>{name}</Text>}
         </Flex>
-        {error && <Error>{ error }</Error> }
+        {error && <Error>{error}</Error>}
       </Box>
     </Box>
   );
 }
 
 AudioSelectForm.propTypes = {
-  handleFileSelect: T.func.isRequired
+  handleFileSelect: T.func.isRequired,
 };

--- a/src/app/search/hooks/useUploadValidation.js
+++ b/src/app/search/hooks/useUploadValidation.js
@@ -15,21 +15,37 @@ const validate = async (file) => {
   return errors;
 };
 
-export default function useUploadValidation(onValid) {
+const validatorAlt = async (file) => {
+  const duration = await getDuration(file);
+  if (duration > MAX_AUDIO_LENGTH) {
+    return {
+      code: 'Audio file too long',
+      message: 'The audio length exceeds the limit of 5 minutes. Upload a shorter recording.',
+    };
+  }
+  if (file.size > MAX_AUDIO_SIZE) {
+    return {
+      code:'File too large', 
+      message: 'The file size exceeds the limit of 1GB. Upload a smaller file.'
+    };
+  }
+  return null;
+};
+
+export default function useUploadValidation() {
   const [ error, setError ] = useState();
 
-  const handleFileChange = useCallback(async (e) => {
-    const file = e.target.files[0];
+  const validator = useCallback(async (file) => {
     const errors = await validate(file);
     if (errors.length > 0) {
       setError(<><b>{file.name}</b>&nbsp;{errors.join(' ')}</>);
     } else {
-      onValid(file);
+      return null;
     }
-  }, [onValid]);
+  }, []);
 
   return {
     error,
-    handleFileChange
+    validator
   };
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,4 +1,10 @@
 const ACCEPTED_AUDIO_TYPES = ['.mp3', '.wav', '.flac', '.m4a'];
+const ACCEPTED_FILE_TYPES = {
+  'audio/mpeg': ['.mp3'],
+  'audio/wav': ['.wav'],
+  'audio/flac': ['.flac'],
+  'audio/mp4': ['.m4a'],
+};
 const MAX_AUDIO_CLIP_LENGTH = 5; // seconds
 const MAX_AUDIO_SIZE = 1073741824; // 1GB
 const MAX_AUDIO_LENGTH = 300; // seconds
@@ -8,10 +14,11 @@ const SEARCH_API = 'https://api.bioacoustics.ds.io/api/v1';
 
 export {
   ACCEPTED_AUDIO_TYPES,
+  ACCEPTED_FILE_TYPES,
   MAX_AUDIO_CLIP_LENGTH,
   MAX_AUDIO_SIZE,
   MAX_AUDIO_LENGTH,
   RESULTS_MAX,
   RESULTS_DISPLAY_PAGE_SIZE,
-  SEARCH_API
+  SEARCH_API,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,6 +2180,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+attr-accept@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
@@ -3208,6 +3213,13 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-selector@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.6.0.tgz#fa0a8d9007b829504db4d07dd4de0310b65287dc"
+  integrity sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==
+  dependencies:
+    tslib "^2.4.0"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -4946,6 +4958,15 @@ react-dom@18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-dropzone@^14.2.3:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.3.tgz#0acab68308fda2d54d1273a1e626264e13d4e84b"
+  integrity sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==
+  dependencies:
+    attr-accept "^2.2.2"
+    file-selector "^0.6.0"
+    prop-types "^15.8.1"
 
 react-fast-compare@3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Contributes to #18 
This is somewhat executed, but I've run into issues with `react-dropzone`'s error validation. The custom `validator` expects an array of objects/single object with error codes and messages, or null. ([docs](https://react-dropzone.js.org/#section-custom-validation)). I'm currently stuck getting the validator to return either a fulfilled promise or null, given that the validation is async. This issue has more details: https://github.com/react-dropzone/react-dropzone/issues/1161

Functionality without validation:

https://github.com/developmentseed/bioacoustics-frontend/assets/12634024/8a70e30e-a79d-4b73-9cb7-fb725a898625



I've commented out the validator, so that you can test the functionality. Some removal of `useCallback`, hooks, async functions or combinations therein may yield the right solution. (see `validatorAlt` function)