### PR TITLE
fix: Enable jest mocks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,8 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
+  automock: false,
+  resetMocks: false,
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,3 +9,4 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
   disconnect: jest.fn(),
 }));
+require('jest-fetch-mock').enableMocks();

--- a/src/app/search/results/index.test.jsx
+++ b/src/app/search/results/index.test.jsx
@@ -13,7 +13,7 @@ describe('Results', () => {
     fetch.mockResponseOnce(JSON.stringify({
       data: [
         { id: 1, name: 'Site A' },
-        { id: 2, name: 'Site B'} 
+        { id: 2, name: 'Site B' }
       ]
     }));
     window.URL.createObjectURL = () => 'https://localhost/123-456';
@@ -25,6 +25,7 @@ describe('Results', () => {
         <Results isLoading={true} results={[]} />
       </SitesProvider>
     );
+
     expect(screen.queryByTestId('loading')).toBeInTheDocument();
   });
 
@@ -37,6 +38,7 @@ describe('Results', () => {
         />
       </SitesProvider>
     );
+
     expect(screen.queryByTestId('results-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('results-grid')).toBeInTheDocument();
   });
@@ -50,6 +52,7 @@ describe('Results', () => {
         />
       </SitesProvider>
     );
+
     expect(screen.queryByTestId('results-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('results-grid')).toBeInTheDocument();
 
@@ -67,6 +70,7 @@ describe('Results', () => {
         />
       </SitesProvider>
     );
+
     expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
     expect(screen.queryByTestId('results-table')).not.toBeInTheDocument();
 


### PR DESCRIPTION
Fix the broken build. The tests were still querying the API, instead of using the mock responses. 
