### PR TITLE
fix: Filter sites without geometries

### DIFF
--- a/src/app/search/context/sites.js
+++ b/src/app/search/context/sites.js
@@ -7,9 +7,10 @@ export function SitesProvider({ children }) {
   const [ sites, setSites ] = useState([]);
 
   useEffect(() => {
-    fetch('https://api.bioacoustics.ds.io/api/v1/a2o/sites/?direction=asc&items=341&order_by=name')
+    fetch('https://api.bioacoustics.ds.io/api/v1/a2o/sites?direction=asc&items=341&order_by=name')
       .then(r => r.json())
-      .then(r => setSites(r.data));
+      .then(r => r.data.filter(({ custom_latitude, custom_longitude }) => custom_latitude && custom_longitude))
+      .then(setSites);
   }, []);
 
   const contextValue = useMemo(() =>({ sites }), [sites]);


### PR DESCRIPTION
Resolves #115 

Filters the sites on the front-end because API filtering isn't enable in the backend, according to an email from Anthony:

> It looks like we haven't enabled filtering for lat/longs. We're emitting obfuscated locations for security purposes, but the obfuscation is applied in the model - not in the database. If we did allow filtering, then one could by process of using filters for elimination deduce the real location - not that anyone cares enough for this to be a real risk.