### PR TITLE
feat: Show best match per recording

### DIFF
--- a/src/app/search/results/components/filters/TopResultCheckbox.jsx
+++ b/src/app/search/results/components/filters/TopResultCheckbox.jsx
@@ -1,0 +1,13 @@
+import T from 'prop-types';
+import { Checkbox } from '@chakra-ui/react';
+
+export default function TopResultCheckbox({ isChecked, onChange }) {
+  return (
+    <Checkbox isChecked={isChecked} onChange={onChange}>Best match per recording only</Checkbox>
+  );
+}
+
+TopResultCheckbox.propTypes = {
+  isChecked: T.bool,
+  onChange: T.func.isRequired
+};

--- a/src/app/search/results/components/filters/index.js
+++ b/src/app/search/results/components/filters/index.js
@@ -2,10 +2,12 @@ import SitesFilter from './SitesFilter';
 import DateFilter from './DateFilter';
 import Chips from './Chips';
 import TimeFilter from './TimeFilter';
+import TopResultCheckbox from './TopResultCheckbox';
 
 export {
   DateFilter,
   SitesFilter,
   Chips,
-  TimeFilter
+  TimeFilter,
+  TopResultCheckbox
 };

--- a/src/app/search/results/hooks/usePaginatedResults.js
+++ b/src/app/search/results/hooks/usePaginatedResults.js
@@ -6,12 +6,14 @@ export default function usePaginatedResults(results) {
   const [ selectedSites, setSelectedSites ] = useState([]);
   const [ selectedDates, setSelectedDates ] = useState([]);
   const [ selectedTimes, setSelectedTimes ] = useState([0, 24]);
+  const [ topMatchPerRecording, setTopMatchPerRecording ] = useState(false);
 
   // Reset page when the filters were changed
   useEffect(() => {
     setPage(1);
   }, [selectedSites, selectedDates, selectedTimes]);
 
+  const recordingsInResults = [];
   const filterFunc = (res) => {
     const filters = [];
     if (selectedSites.length > 0) {
@@ -26,6 +28,14 @@ export default function usePaginatedResults(results) {
       const date = new Date(res.entity.file_timestamp * 1000 + res.entity.clip_offset_in_file);
       const hour = date.getUTCHours();
       filters.push(selectedTimes[0] <= hour && selectedTimes[1] >= hour);
+    }
+    if (topMatchPerRecording) {
+      if (!recordingsInResults.includes(res.entity.filename)) {
+        recordingsInResults.push(res.entity.filename);
+        filters.push(true);
+      } else {
+        filters.push(false);
+      }
     }
     
     if (filters.length > 0)
@@ -56,6 +66,10 @@ export default function usePaginatedResults(results) {
     nextPageProps: {
       isDisabled: numMatches === 0 || page === Math.ceil(numMatches / RESULTS_DISPLAY_PAGE_SIZE),
       onClick: () => setPage(page + 1)
+    },
+    topMatchPerRecordingProps: {
+      isChecked: topMatchPerRecording,
+      onChange: e => setTopMatchPerRecording(e.target.checked)
     }
   };
 }

--- a/src/app/search/results/hooks/usePaginatedResults.test.js
+++ b/src/app/search/results/hooks/usePaginatedResults.test.js
@@ -6,7 +6,8 @@ const results = Array(72).fill(0).map((_, i) => ({
   entity: {
     site_id: i % 3,
     file_timestamp: new Date(Date.UTC(2021, i % 3, 10, i % 3, 0)).getTime() / 1000,
-    clip_offset_in_file: 0
+    clip_offset_in_file: 0,
+    filename: `audio_${i % 3}.mp3`
   }
 }));
 
@@ -97,6 +98,15 @@ describe('usePaginatedResults', () => {
     const { resultPage } = result.current;
     const correctResults = resultPage.every(r => new Date(r.entity.file_timestamp * 1000).getUTCHours() <= 1);
     expect(correctResults).toBeTruthy();
+  });
+
+  it('filters top result per recording', () => {
+    const { result } = renderHook(() => usePaginatedResults(results));
+    act(() => {
+      result.current.topMatchPerRecordingProps.onChange({ target : { checked: true }});
+    });
+    const { resultPage } = result.current;
+    expect(resultPage.length).toEqual(3);
   });
 
   it('disables pagination buttons when there are now matches', () => {

--- a/src/app/search/results/index.js
+++ b/src/app/search/results/index.js
@@ -19,7 +19,7 @@ import { Loading } from '@/components';
 import { TMatch } from '@/types';
 import TableView from './TableView';
 import GridView from './GridView';
-import { SitesFilter, DateFilter, TimeFilter, Chips } from './components/filters';
+import { SitesFilter, DateFilter, TimeFilter, Chips, TopResultCheckbox } from './components/filters';
 import { usePaginatedResults, useDownload } from './hooks';
 import MapView from './MapView';
 
@@ -44,6 +44,7 @@ export default function Results({ isLoading, results }) {
     setSelectedDates,
     selectedTimes,
     setSelectedTimes,
+    topMatchPerRecordingProps,
   } = usePaginatedResults(results);
   const { selectedResults, toggleSelect, clearSelect, downloadLink } = useDownload(results);
 
@@ -78,6 +79,7 @@ export default function Results({ isLoading, results }) {
               <SitesFilter selectedSites={selectedSites} setSelectedSites={setSelectedSites} />
               <DateFilter selectedDates={selectedDates} setSelectedDates={setSelectedDates} />
               <TimeFilter selectedTimes={selectedTimes} setSelectedTimes={setSelectedTimes} />
+              <TopResultCheckbox {...topMatchPerRecordingProps} />
             </HStack>
             <Chips
               selectedSites={selectedSites}


### PR DESCRIPTION
Resolves #54 

- Adds checkbox to the filters that allows to limit the results to the top match per recording
- Extends `usePaginatedResults` with the top-match filter. 