### PR TITLE
feat: Add drag-and-drop file upload

### DIFF
--- a/src/app/search/AudioResetForm.jsx
+++ b/src/app/search/AudioResetForm.jsx
@@ -14,7 +14,6 @@ import {
 } from '@chakra-ui/react';
 import { MdChevronLeft } from 'react-icons/md';
 
-import { ACCEPTED_AUDIO_TYPES } from '@/settings';
 import { Error } from '@/components';
 
 export default function AudioResetForm({ error, setFile }) {
@@ -24,8 +23,7 @@ export default function AudioResetForm({ error, setFile }) {
     onClose();
     const inputEl = document.createElement('input');
     inputEl.setAttribute('type', 'file');
-    inputEl.setAttribute('accept', ACCEPTED_AUDIO_TYPES.join(','));
-    inputEl.addEventListener('change', setFile);
+    inputEl.addEventListener('change', (e) => setFile(e.target.files));
     inputEl.click();
   };
 

--- a/src/app/search/AudioSelectForm.jsx
+++ b/src/app/search/AudioSelectForm.jsx
@@ -1,29 +1,55 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import T from 'prop-types';
 import { Box, Button, Flex, Text } from '@chakra-ui/react';
 
-import { ACCEPTED_AUDIO_TYPES } from '@/settings';
 import { Error } from '@/components';
 
 export default function AudioSelectForm({ error, handleFileSelect }) {
   const inputRef = useRef();
-  const [ name, setName ] = useState();
+  const dropZoneRef = useRef();
+  const [ dragOver, setDragOver ] = useState(false);
 
-  const handleFileChange = async (e) => {
-    setName(e.target.files[0].name);
-    handleFileSelect(e);
-  };
+  const handleFileChange = async (e) => handleFileSelect(e.target.files);
+
+  useEffect(() => {
+    const dropZone = dropZoneRef.current;
+    const handleDragOver = (e) => {
+      e.preventDefault();
+      setDragOver(true);
+    };
+    const handleDragLeave = (e) => {
+      e.preventDefault();
+      setDragOver(false);
+    };
+    const handleDrop = (e) => {
+      e.preventDefault();
+      setDragOver(false);
+      handleFileSelect(e.dataTransfer.files);
+    };
+
+    dropZone.addEventListener('dragover', handleDragOver);
+    dropZone.addEventListener('dragleave', handleDragLeave);
+    dropZone.addEventListener('drop', handleDrop);
+
+    return () => {
+      dropZone.removeEventListener('dragover', handleDragOver);
+      dropZone.removeEventListener('dragleave', handleDragLeave);
+      dropZone.removeEventListener('drop', handleDrop);
+    };
+  }, [handleFileSelect]);
 
   return (
     <Box bg="white" p="2" borderRadius="12" boxShadow="lg">
       <Box
         border="2px dashed"
-        bg="blackAlpha.50"
-        borderColor="primary.400"
+        bg={dragOver ? 'green.50' : 'blackAlpha.50'}
+        borderColor={dragOver ? 'primary.400' : 'neutral.300'}
         borderRadius="6"
         textAlign="center"
         p="5"
         mt="1"
+        ref={dropZoneRef}
+        id="dropzone"
       >
         <Text>Click to select from your device</Text>
         <Text
@@ -41,7 +67,6 @@ export default function AudioSelectForm({ error, handleFileSelect }) {
           onChange={handleFileChange}
           aria-describedby="file-hint"
           style={{ display: 'none' }}
-          accept={ACCEPTED_AUDIO_TYPES.join(',')}
         />
         <Flex gap="2" justifyContent="center" alignItems={['center', null, 'baseline']} flexDirection={['column', null, 'row']}>
           <Button
@@ -52,7 +77,6 @@ export default function AudioSelectForm({ error, handleFileSelect }) {
           >
             Select File
           </Button>
-          {name && <Text>{name}</Text>}
         </Flex>
         {error && <Error>{ error }</Error> }
       </Box>

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,4 +1,9 @@
-const ACCEPTED_AUDIO_TYPES = ['.mp3', '.wav', '.flac', '.m4a'];
+const ACCEPTED_AUDIO_TYPES = [
+  'audio/mpeg',
+  'audio/wav',
+  'audio/flac',
+  'audio/x-m4a'
+];
 const MAX_AUDIO_CLIP_LENGTH = 5; // seconds
 const MAX_AUDIO_SIZE = 1073741824; // 1GB
 const MAX_AUDIO_LENGTH = 300; // seconds


### PR DESCRIPTION
Resolves #18 

Adds drag-and-drop file upload. I decided not to use a library for this because it's straightforward to implement using vanilla JS and we don't have to change the way we validate files. 

- Adds an effect hook to register relevant drag-and-drop event handlers to `AudioSelectForm`
- Add additional validation to file-upload handling
  - Check that only one file was uploaded
  - Check that the uploaded file is a audio file
- Change the file validation, so instead of returning an error array, we only return the error string. 
