### PR TITLE
fix: Remove audio-player elements after component unmount

### DIFF
--- a/src/app/search/hooks/useAudioPLayer.js
+++ b/src/app/search/hooks/useAudioPLayer.js
@@ -20,15 +20,22 @@ export default function useAudioPlayer(audioUrl, clipStart, clipLength) {
     const el = document.createElement('audio');
     el.setAttribute('src', audioUrl);
     el.setAttribute('preload', 'metadata');
-    el.addEventListener('loadedmetadata', () => {
-      setDuration(el.duration);
-    });
 
-    el.addEventListener('ended', () => {
+    const handleLoadedMedia = () => setDuration(el.duration);
+    const handlePlayend = () => {
       setIsPlaying(false);
       clearInterval(intervalRef.current);
-    });
+    };
+
+    el.addEventListener('loadedmetadata', handleLoadedMedia);
+    el.addEventListener('ended', handlePlayend);
     setAudioElement(el);
+
+    return () => {
+      el.removeEventListener('loadedmetadata', handleLoadedMedia);
+      el.removeEventListener('ended', handlePlayend);
+      el.remove();
+    };
   }, [audioUrl]);
 
   // set the start time when a new clip is set


### PR DESCRIPTION
Chrome has a limit of ~100 audio elements that can be mounted at a given time. When paging through the results, this means at some point, no new audio elements can be added to the DOM and so the sounds cannot be played.

Added changes to clean up the audio elements and event handlers when the `useAudioPlayer` hook is unmounted. 