### PR TITLE
fix: Initialise MediaRecorder in Safari with mp4 mimetype

### DIFF
--- a/src/app/search/AudioRecorder.jsx
+++ b/src/app/search/AudioRecorder.jsx
@@ -9,21 +9,30 @@ export default function AudioRecorder({ setFile }) {
   const handleRecordStart = () => {
     const chunks = [];
     const startTime = Date.now();
+    let type = 'audio/webm';
 
     const handleData = (({ data }) => {
       data && data.size > 0 && chunks.push(data);
     });
     const handleRecordStop = async () => {
       const duration = Date.now() - startTime;
-      const blob = new Blob(chunks, { type: 'audio/webm' });
+      const blob = new Blob(chunks, { type });
       const blobWithDuration = await fixWebmDuration(blob, duration, {  logger: false });
       const name = `Recording ${new Date().toUTCString()}.webm`;
-      setFile([new File([blobWithDuration], name, { type: 'audio/webm' })]);
+      setFile([new File([blobWithDuration], name, { type })]);
     };
 
     navigator.mediaDevices.getUserMedia({ audio: true })
       .then((stream) => {
-        const m = new MediaRecorder(stream);
+        let m;
+        try {
+          // Safari requires mp4 recordings or it won't play back the recording
+          // Chrome and Firefox will not initialise MediaRecorder with mp4
+          m = new MediaRecorder(stream, { mimeType: 'audio/mp4' });
+          type = 'audio/mp4';
+        } catch (e) {
+          m = new MediaRecorder(stream);
+        }
         m.addEventListener('dataavailable', handleData);
         m.addEventListener('stop', handleRecordStop);
     

--- a/src/settings.js
+++ b/src/settings.js
@@ -3,7 +3,8 @@ const ACCEPTED_AUDIO_TYPES = [
   'audio/wav',
   'audio/flac',
   'audio/x-m4a',
-  'audio/webm'
+  'audio/webm',
+  'audio/mp4'
 ];
 const MAX_AUDIO_CLIP_LENGTH = 5; // seconds
 const MAX_AUDIO_SIZE = 1073741824; // 1GB

--- a/src/utils/getDuration.js
+++ b/src/utils/getDuration.js
@@ -1,11 +1,12 @@
 export default function getDuration(file) {
   return new Promise((resolve) => {
     const audioUrl = URL.createObjectURL(file);
-    const el = document.createElement('audio');
+    const el = new Audio();
     el.setAttribute('src', audioUrl);
     el.setAttribute('preload', 'metadata');
     el.addEventListener('loadedmetadata', () => {
       resolve(el.duration);
     });
+    el.load();
   });
 }


### PR DESCRIPTION
Fixes #135 

Safari can't play webm recordings so the file validation gets stuck when determining the duration of the audio and never loads the file. I've changed the `MediaRecorder` initialisation to use mp4 instead, which breaks in Chrome and Firefox so we need to awkwardly initialise in a `try..catch` block. 
