### PR TITLE
fix: Add disabled button hover state

### DIFF
--- a/src/app/theme/Button.js
+++ b/src/app/theme/Button.js
@@ -7,7 +7,14 @@ const Button = defineStyleConfig({
   variants: {
     primary: {
       bgColor: 'primary.400',
-      color: 'white'
+      color: 'white',
+      _hover: {
+        _disabled: {
+          backgroundColor: 'primary.400',
+          color: 'white',
+          opacity: 0.4
+        }
+      },
     },
     outline: {
       color: 'primary.400',


### PR DESCRIPTION
Small bug fix that specifies the hover state for disabled buttons so the remain visible. 
