### PR TITLE
fix: Enforce https for permalink file downloads

### DIFF
--- a/src/app/search/results/components/ShareButton.jsx
+++ b/src/app/search/results/components/ShareButton.jsx
@@ -43,7 +43,7 @@ export default function ShareButton({ file }) {
       })
         .then(r => r.json())
         .then(({ bucket_name, filename }) => {
-          const fileUrl = `http://${bucket_name}.storage.googleapis.com/${filename}`;
+          const fileUrl = `https://${bucket_name}.storage.googleapis.com/${filename}`;
           resolve(`${protocol}//${host}/search?q=${fileUrl}&${appState.urlEncode(keys)}`);
         });
 


### PR DESCRIPTION
Fixes file downloads for shared links by enforcing https for the file URL
