### PR TITLE
fix: Add trailing slash to random link

### DIFF
--- a/src/app/random/page.js
+++ b/src/app/random/page.js
@@ -10,5 +10,5 @@ const recordings = [
 
 export default function Random() {
   const index = Math.floor(Math.random() * recordings.length - 1);
-  redirect(`/search?q=${encodeURIComponent(recordings[index])}`);
+  redirect(`/search/?q=${encodeURIComponent(recordings[index])}`);
 }

--- a/src/app/search/AudioSelectForm.jsx
+++ b/src/app/search/AudioSelectForm.jsx
@@ -81,7 +81,7 @@ export default function AudioSelectForm({ error, handleFileSelect }) {
           </Button>
           <AudioRecorder setFile={handleFileSelect} />
         </Flex>
-        <Box mt="2" fontSize="sm"><Link href="/random" textDecoration="underline">I&apos;m feeling lucky</Link></Box>
+        <Box mt="2" fontSize="sm"><Link href="/random/" textDecoration="underline">I&apos;m feeling lucky</Link></Box>
         {error && <Error>{ error }</Error> }
       </Box>
     </Box>


### PR DESCRIPTION
I can't explain it but adding a trailing slash to the random link fixes the I'm feeling lucky result.

I think it has to do with how NextJS does its routing and how the server is set up. Without the trailing slash, the server first returns a redirect to `/random/index.html`, which then redirects to `/search?q=undefined`. I could be that the JS isn't initialised properly on `/random/index.html` so the URL randomiser doesn't resolve properly. 