### PR TITLE
Use mapbox outdoors style

### DIFF
--- a/src/app/search/results/MapView.jsx
+++ b/src/app/search/results/MapView.jsx
@@ -139,7 +139,7 @@ export default function MapView({ results, bboxFilter, setBboxFilter }) {
           latitude: -25.7302804,
           zoom: 3
         }}
-        mapStyle="mapbox://styles/mapbox/light-v11"
+        mapStyle="mapbox://styles/mapbox/outdoors-v12"
         mapboxAccessToken={MAPBOX_TOKEN}
         interactiveLayerIds={[clusterLabelStyle.id]}
         onClick={handleClusterClick}

--- a/src/app/search/results/components/filters/SitesFilterMap.jsx
+++ b/src/app/search/results/components/filters/SitesFilterMap.jsx
@@ -171,7 +171,7 @@ export default function SitesFilterMap({ selectedSites, setSelectedSites, isDraw
         latitude: -26.7302804,
         zoom: 3
       }}
-      mapStyle="mapbox://styles/mapbox/light-v11"
+      mapStyle="mapbox://styles/mapbox/outdoors-v12"
       mapboxAccessToken={MAPBOX_TOKEN}
       ref={mapRef}
       interactiveLayerIds={[markerStyle.id]}


### PR DESCRIPTION
Suggestion - use mapbox outdoors style to add some color to the platform. Mapbox lite was used for design prototyping but never updated. (alternatively - create custom style; the outdoors style is a little over saturated)
![Screen Shot 2023-08-25 at 5 38 02 PM](https://github.com/developmentseed/bioacoustics-frontend/assets/12634024/3c79d2b1-c9f6-4fa4-822f-8c8d0b61d655)

