### PR TITLE
fix: Calculate label interval based on duration and spectrogram size

### DIFF
--- a/src/app/search/hooks/useSpectrogram.js
+++ b/src/app/search/hooks/useSpectrogram.js
@@ -24,6 +24,11 @@ export default function useSpectrogramNavigation(file, waveformId, spectrogramId
 
   // Initialises the spectrogram with the audio data
   useEffect(() => {
+    const pixelPerTick = 25;
+    const width = spectrogramRef.current.clientWidth;
+    const numberOfTicks = width / pixelPerTick;
+    const timeInterval = Math.round(duration / numberOfTicks) || 0.5;
+
     var wavesurfer = WaveSurfer.create({
       container: `#${CSS.escape(waveformId)}`,
       scrollParent: true,
@@ -36,7 +41,7 @@ export default function useSpectrogramNavigation(file, waveformId, spectrogramId
         }),
         TimelinePlugin.create({
           container: '#timeline',
-          timeInterval: 0.5,
+          timeInterval,
           primaryLabelInterval: 2,
           secondaryLabelInterval: 10,
         })
@@ -52,7 +57,7 @@ export default function useSpectrogramNavigation(file, waveformId, spectrogramId
     wavesurfer.seekAndCenter(0.5);
     setZoom(1);
     wavesurferRef.current = wavesurfer;
-  }, [file, waveformId, spectrogramId, wavesurferRef]);
+  }, [file, waveformId, spectrogramId, wavesurferRef, duration]);
 
   useEffect(() => {
     const width = spectrogramRef.current.clientWidth;


### PR DESCRIPTION
Fixes the issue where timeline labels appear to be squashed together with long audio files.

The new approach calculates the tick interval by taking into account both the duration of the audio and the width of the spectrogram (in px), assuming we want to show one tick every 25 pixels. 
