### PR TITLE
fix: Remove -1 from randomiser

### DIFF
--- a/src/app/random/page.js
+++ b/src/app/random/page.js
@@ -9,6 +9,6 @@ const recordings = [
 ];
 
 export default function Random() {
-  const index = Math.floor(Math.random() * recordings.length - 1);
+  const index = Math.floor(Math.random() * recordings.length);
   redirect(`/search/?q=${encodeURIComponent(recordings[index])}`);
 }

--- a/src/app/search/AudioSelectForm.jsx
+++ b/src/app/search/AudioSelectForm.jsx
@@ -1,10 +1,10 @@
 import { useRef, useState, useEffect } from 'react';
 import T from 'prop-types';
-import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import NextLink from 'next/link';
+import { Box, Button, Flex, Text, Link } from '@chakra-ui/react';
 
 import { Error } from '@/components';
 import AudioRecorder from './AudioRecorder';
-import { Link } from '@chakra-ui/react';
 
 export default function AudioSelectForm({ error, handleFileSelect }) {
   const inputRef = useRef();
@@ -81,7 +81,7 @@ export default function AudioSelectForm({ error, handleFileSelect }) {
           </Button>
           <AudioRecorder setFile={handleFileSelect} />
         </Flex>
-        <Box mt="2" fontSize="sm"><Link href="/random/" textDecoration="underline">I&apos;m feeling lucky</Link></Box>
+        <Box mt="2" fontSize="sm"><Link as={NextLink} href="/random/" textDecoration="underline">I&apos;m feeling lucky</Link></Box>
         {error && <Error>{ error }</Error> }
       </Box>
     </Box>


### PR DESCRIPTION
Fix #154 

I believe the culprit is this line:

```js
const index = Math.floor(Math.random() * recordings.length - 1);
```

For twenty years now, I believed `Math.random()` returns a number between 0 and 1 inclusive, but that's [not the case](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random) (emphasis mine):

> The Math.random() static method returns a floating-point, pseudo-random number that's greater than or equal to 0 and **less than 1**

So in cases when `Math.random()` returns a number < 0.2, `index` results in `-1`. `-1` used to get an element from an array returns `undefined`, unless you have previously set the value (like `someArray[-1] = "some value"`). 

And we're not going to talk about the fact that I forgot basic math; the line above should have read:

```js
const index = Math.floor(Math.random() * (recordings.length - 1));
```

---

I also turned the "I'm feeling lucky" link into a `NextLink` so the page is preloaded. 