### PR TITLE
fix: Prevent default form-submit behviour

### DIFF
--- a/src/app/search/hooks/useSearchForm.js
+++ b/src/app/search/hooks/useSearchForm.js
@@ -138,7 +138,8 @@ export default function useSearchForm() {
   /**
    * Submit the form
    */
-  const handleFormSubmit = useCallback(async () => {
+  const handleFormSubmit = useCallback(async (e) => {
+    e.preventDefault();
     setIsSubmitting(true);
     setResults([]);
 


### PR DESCRIPTION
Fixes #156 

Prevent default event behaviour, which makes Firefox submit the form using GET, and therefore reloading the page. 