### PR TITLE
fix: Set minPxPerSecond for spectrogram

### DIFF
--- a/src/app/search/hooks/useSpectrogram.js
+++ b/src/app/search/hooks/useSpectrogram.js
@@ -32,6 +32,7 @@ export default function useSpectrogramNavigation(file, waveformId, spectrogramId
     var wavesurfer = WaveSurfer.create({
       container: `#${CSS.escape(waveformId)}`,
       scrollParent: true,
+      minPxPerSec: 1,
       plugins: [
         SpectrogramPlugin.create({
             wavesurfer: wavesurfer,


### PR DESCRIPTION
Sets `minPxPerSec` for spectrogram, so long audio uploads are fully rendered. 

`minPxPerSec` defines the minimum number of pixels to render one second in the spectrogram. So long audio files might not fit into the space allocated for the spectrogram on the page. The clipper always assumes, that the whole spectrogram is rendered, so the seconds shown in the labels and in the clipped part sometimes don't match for long audio files. 

