### PR TITLE
fix: Wrap random-redirect in useEffect

### DIFF
--- a/src/app/random/page.js
+++ b/src/app/random/page.js
@@ -1,3 +1,5 @@
+'use client';
+import { useEffect } from 'react';
 import { redirect } from 'next/navigation';
 
 const recordings = [
@@ -9,6 +11,8 @@ const recordings = [
 ];
 
 export default function Random() {
-  const index = Math.floor(Math.random() * recordings.length);
-  redirect(`/search/?q=${encodeURIComponent(recordings[index])}`);
+  useEffect(() => {
+    const index = Math.floor(Math.random() * recordings.length);
+    redirect(`/search/?q=${encodeURIComponent(recordings[index])}`);
+  }, []);
 }


### PR DESCRIPTION
Fixes #158

Wraps the redirect in `useEffect`, which ensures it's executed every time the page is loaded and not cached. 
